### PR TITLE
Ignore missing variable keys in transform

### DIFF
--- a/src/match.ts
+++ b/src/match.ts
@@ -78,21 +78,20 @@ const compilePattern = (pattern: string): RegExp => {
 }
 
 export const transform = (pattern: string, variableMaps: VariableMap[]): string[] => {
-  const paths = new Set<string>()
+  const transformedPaths = new Set<string>()
   for (const variableMap of variableMaps) {
-    const path = pattern
-      .split('/')
-      .map((pathSegment) =>
-        pathSegment.replaceAll(/:([a-zA-Z0-9]+)/g, (_, variableKey: string): string => {
-          const variableValue = variableMap[variableKey]
-          if (variableValue === undefined) {
-            return '*'
-          }
-          return variableValue
-        }),
-      )
-      .join('/')
-    paths.add(path)
+    let anyUndefinedVariable = false
+    const transformedPath = pattern.replaceAll(/:([a-zA-Z0-9]+)/g, (_, variableKey: string): string => {
+      const variableValue = variableMap[variableKey]
+      if (variableValue === undefined) {
+        anyUndefinedVariable = true
+        return ''
+      }
+      return variableValue
+    })
+    if (!anyUndefinedVariable) {
+      transformedPaths.add(transformedPath)
+    }
   }
-  return [...paths]
+  return [...transformedPaths]
 }

--- a/tests/match.test.ts
+++ b/tests/match.test.ts
@@ -314,7 +314,7 @@ describe('transform', () => {
     ])
   })
 
-  it('handles missing group values by replacing with asterisk', () => {
+  it('ignores missing variable keys', () => {
     const variableMaps: VariableMap[] = [
       {
         cluster: 'staging',
@@ -327,7 +327,7 @@ describe('transform', () => {
     ]
     const paths = transform('clusters/:cluster/:component/kustomization.yaml', variableMaps)
     expect(paths).toStrictEqual([
-      'clusters/staging/*/kustomization.yaml',
+      // 'clusters/staging/?/kustomization.yaml' is ignored
       'clusters/production/coredns/kustomization.yaml',
     ])
   })


### PR DESCRIPTION
Since v2, the wildcard fallback has been removed. This will fix the transform logic.
