### PR TITLE
Exclude deleted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ jobs:
 
 This action determines the changed files as follows:
 
-- For `pull_request` or `pull_request_target` events, it compares the base commit and head commit of the pull request.
+- For `pull_request` or `pull_request_target` events, it compares the base branch and head branch of the pull request.
+  It excludes the deleted files.
 - For `push` events, it compares the before commit and after commit.
+  It excludes the deleted files.
 - Otherwise, it falls back to the working directory files.
 
 You can exclude files from the path patterns by using the `!` prefix.

--- a/src/git.ts
+++ b/src/git.ts
@@ -5,12 +5,26 @@ import { type Context, getToken } from './github.js'
 
 export const compareMergeCommit = async (merge: string, context: Context): Promise<string[]> => {
   return await withWorkspaceOrTemporaryDirectory(context, async (cwd) => {
-    await exec.exec('git', ['fetch', '--quiet', '--no-tags', '--depth=2', 'origin', merge], { cwd })
+    await exec.exec(
+      'git',
+      [
+        'fetch',
+        '--quiet',
+        '--no-tags',
+        // Fetch the merge commit and its first parent commit.
+        '--depth=2',
+        'origin',
+        merge,
+      ],
+      { cwd },
+    )
     const gitDiff = await exec.getExecOutput(
       'git',
       [
         'diff',
         '--name-only',
+        // Exclude the deleted files.
+        '--diff-filter=d',
         // The merge commit has two parents.
         // The first parent is the base branch to be merged into.
         // The second parent is the head commit.
@@ -25,8 +39,32 @@ export const compareMergeCommit = async (merge: string, context: Context): Promi
 
 export const compareTwoCommits = async (before: string, after: string, context: Context): Promise<string[]> => {
   return await withWorkspaceOrTemporaryDirectory(context, async (cwd) => {
-    await exec.exec('git', ['fetch', '--quiet', '--no-tags', '--depth=1', 'origin', before, after], { cwd })
-    const gitDiff = await exec.getExecOutput('git', ['diff', '--name-only', before, after], { cwd })
+    await exec.exec(
+      'git',
+      [
+        'fetch',
+        '--quiet',
+        '--no-tags',
+        // Fetch the before commit and after commit.
+        '--depth=1',
+        'origin',
+        before,
+        after,
+      ],
+      { cwd },
+    )
+    const gitDiff = await exec.getExecOutput(
+      'git',
+      [
+        'diff',
+        '--name-only',
+        // Exclude the deleted files.
+        '--diff-filter=d',
+        before,
+        after,
+      ],
+      { cwd },
+    )
     return gitDiff.stdout.trim().split('\n')
   })
 }


### PR DESCRIPTION
This changes the comparing option to exclude the deleted files between the commits. Since this action is designed for testing the cross-cutting concern, it does not need to test the deleted files.
